### PR TITLE
Add first mackerel plugin def

### DIFF
--- a/plugins/mackerel-plugin-sample.json
+++ b/plugins/mackerel-plugin-sample.json
@@ -1,0 +1,4 @@
+{
+    "source": "mackerelio/mackerel-plugin-sample",
+    "description": "A sample mackerel plugin"
+}


### PR DESCRIPTION
I add a mackerel-plugin-sample plugin def to plugins/ directory.  I plan that when there is definition in plugins/ directory, we can `mkr plugin install <plugin_name>` (this implementation is work in progress).

I have not written README.md for contributors yet.  I'm going to write it after I implement `mkr plugin install <plugin_name>` feature.